### PR TITLE
Point to correct repo in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ This fork of a fork of clj-http-lite is usable with [Babashka](https://github.co
 You can obtain it as a git dep using the `clojure` tool. Put this in your `deps.edn`:
 
 ``` clojure
-{:deps {clj-http-lite {:git/url "https://github.com/borkdude/clj-http-lite" :sha "f44ebe45446f0f44f2b73761d102af3da6d0a13e"}}}
+{:deps {clj-http-lite {:git/url "https://github.com/babashka/clj-http-lite" :sha "f44ebe45446f0f44f2b73761d102af3da6d0a13e"}}}
 ```
 
 or use any later SHA. And then use the library with Babashka as follows:


### PR DESCRIPTION
Hi. This is fix for a typo on what I think are old instructions. When I tried running with the current deps.edn, [my CI job failed](https://github.com/cldwalker/bb-clis/runs/938481186?check_suite_focus=true) (see Install deps.edn step). Switching to babashka/clj-http-lite [installs fine](https://github.com/cldwalker/bb-clis/runs/938605762?check_suite_focus=true)